### PR TITLE
feat: add route 53 record for kotetsu.rindrics.com

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -63,6 +63,7 @@ jobs:
           pulumi config set kotetsu:sesReceiverEmail ${{ secrets.SES_RECEIVER_EMAIL }} --non-interactive
           pulumi config set kotetsu:allowedEmailAddresses ${{ vars.ALLOWED_EMAIL_ADDRESSES }} --non-interactive
           pulumi config set --secret kotetsu:githubDispatchToken ${{ secrets.GITHUB_TOKEN }} --non-interactive
+          pulumi config set kotetsu:route53ZoneId ${{ secrets.ROUTE53_ZONE_ID }} --non-interactive
 
       - name: Pulumi preview
         uses: pulumi/actions@v5
@@ -119,6 +120,7 @@ jobs:
           pulumi config set kotetsu:sesReceiverEmail ${{ secrets.SES_RECEIVER_EMAIL }} --non-interactive
           pulumi config set kotetsu:allowedEmailAddresses ${{ vars.ALLOWED_EMAIL_ADDRESSES }} --non-interactive
           pulumi config set --secret kotetsu:githubDispatchToken ${{ secrets.GITHUB_TOKEN }} --non-interactive
+          pulumi config set kotetsu:route53ZoneId ${{ secrets.ROUTE53_ZONE_ID }} --non-interactive
 
       - name: Pulumi up
         uses: pulumi/actions@v5

--- a/infrastructure/email-setup.ts
+++ b/infrastructure/email-setup.ts
@@ -7,6 +7,7 @@ const config = new pulumi.Config('kotetsu');
 const sesReceiverEmail = config.require('sesReceiverEmail');
 const githubDispatchToken = config.requireSecret('githubDispatchToken');
 const allowedEmailAddresses = config.require('allowedEmailAddresses');
+const route53ZoneId = config.require('route53ZoneId');
 
 // 1. Create SNS Topic for SES
 const sesEmailTopic = new aws.sns.Topic('ses-email-topic', {
@@ -96,7 +97,17 @@ new aws.lambda.Permission('allow-sns-invoke', {
 	sourceArn: sesEmailTopic.arn
 });
 
-// 6. Add rule to existing "slackmail" SES Receipt Rule Set
+// 6. Create Route53 MX record for kotetsu.rindrics.com
+new aws.route53.Record('kotetsu-mx-record', {
+	zoneId: route53ZoneId,
+	name: 'kotetsu.rindrics.com',
+	type: 'MX',
+	ttl: 300,
+	records: ['10 inbound-smtp.us-east-1.amazonaws.com'],
+	allowOverwrite: true,
+});
+
+// 7. Add rule to existing "slackmail" SES Receipt Rule Set
 // kotetsu.rindrics.com emails are forwarded to SNS for Lambda processing
 new aws.ses.ReceiptRule('kotetsu-email-to-sns', {
 	ruleSetName: 'main',
@@ -112,7 +123,7 @@ new aws.ses.ReceiptRule('kotetsu-email-to-sns', {
 	]
 });
 
-// 7. Export outputs
+// 8. Export outputs
 export const topicArn = sesEmailTopic.arn;
 export const lambdaFunctionName = emailParserLambda.name;
 export const lambdaFunctionArn = emailParserLambda.arn;


### PR DESCRIPTION
- doing #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced email infrastructure configuration with Route53 MX record setup for domain email routing
  * Updated deployment workflows to include Route53 zone configuration from secrets management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->